### PR TITLE
Fix constraint specification for scikit-image

### DIFF
--- a/requirements/requirements-cv.txt
+++ b/requirements/requirements-cv.txt
@@ -1,6 +1,6 @@
 imageio>=2.5.0
 opencv-python-headless>=4.2.0.32
-scikit-image<0.19.0>=0.16.1
+scikit-image>=0.19.0,<=0.19.1
 torchvision>=0.5.0
 Pillow>=6.1  # torchvision fix (https://github.com/python-pillow/Pillow/issues/4130)
 requests


### PR DESCRIPTION
Installing the latest version of catalyst fails due to an invalid requirements specification. This fixes it.